### PR TITLE
Serialising resources to rdfxml

### DIFF
--- a/lib/EasyRdf/Serialiser/RdfXml.php
+++ b/lib/EasyRdf/Serialiser/RdfXml.php
@@ -65,6 +65,7 @@ class EasyRdf_Serialiser_RdfXml extends EasyRdf_Serialiser
      */
     protected function rdfxmlResource($res, $type='rdf:Description')
     {
+        $this->addPrefix($type);
         if ($res->isBNode()) {
             return "<$type rdf:nodeID=\"".
                    htmlspecialchars($res->getNodeId())."\">";

--- a/test/EasyRdf/Serialiser/RdfXmlTest.php
+++ b/test/EasyRdf/Serialiser/RdfXmlTest.php
@@ -199,4 +199,31 @@ class EasyRdf_Serialiser_RdfXmlTest extends EasyRdf_TestCase
         $this->setExpectedException('EasyRdf_Exception');
         $rdf = $this->_serialiser->serialise($this->_graph, 'unsupportedformat');
     }
+
+    /**
+     * testSerialiseRdfTypeAddsPrefix 
+     * 
+     * A test to assert that serialising a resource with a certain rdf:type 
+     * adds the correct namespace prefix, even if there are no properties tied 
+     * to that particular namespace.
+     */
+    function testSerialiseRdfTypeAddsPrefix( )
+    {
+        $joe = $this->_graph->resource('http://www.example.com/joe#me', 'foaf:Person');
+        $joe->set('dc:creator', 'Max Bloggs');
+
+        $this->assertEquals(
+            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n".
+            "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n".
+            "         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\n".
+            "         xmlns:dc=\"http://purl.org/dc/terms/\">\n" .
+            "\n".
+            "  <foaf:Person rdf:about=\"http://www.example.com/joe#me\">\n".
+            "    <dc:creator>Max Bloggs</dc:creator>\n".
+            "  </foaf:Person>\n".
+            "\n".
+            "</rdf:RDF>\n",
+            $this->_serialiser->serialise($this->_graph, 'rdfxml')
+        );
+    }
 }


### PR DESCRIPTION
Whern serialising to rdfxml a problem occured when a resource had a
certain rdf type, but no properties were being used from the associated
namespace. Currently prefixes were only being added for properties and
not for types.
