### PR TITLE
Fix static

### DIFF
--- a/lib/EasyRdf/Parser/Redland.php
+++ b/lib/EasyRdf/Parser/Redland.php
@@ -110,11 +110,11 @@ class EasyRdf_Parser_Redland extends EasyRdf_Parser
             }
             return $str;
         } else if ($type == 'bnode') {
-            return $this->remapBnode(
+            return EasyRdf_Parser_Redland::remapBnode(
                 librdf_node_get_blank_identifier($node)
             );
         } else {
-            throw new EasyRdf_Exception("Unsupported type: ".$object['type']);
+            throw new EasyRdf_Exception("Unsupported type: ".$type);
         }
     }
 


### PR DESCRIPTION
A partial fix for this error in the phpunit tests:
`PHP Fatal error:  Using $this when not in object context in 
  vendor/njh/easyrdf/lib/EasyRdf/Parser/Redland.php on line 113`

It still generates a warning:

`````` EasyRdf_Parser_RedlandTest::testParseRdfXml
Non-static method EasyRdf_Parser::remapBnode() should not be called statically

  vendor/njh/easyrdf/lib/EasyRdf/Parser/Redland.php:115
  vendor/njh/easyrdf/lib/EasyRdf/Parser/Redland.php:115
  vendor/njh/easyrdf/lib/EasyRdf/Parser/Redland.php:226
  vendor/njh/easyrdf/test/EasyRdf/Parser/RedlandTest.php:64```
Which I didn't have time to try and fix.

PHP 5.3.13 (cli) 
PHPUnit 3.7.9 
``````
