### PR TITLE
Support for loadHTML()

### DIFF
--- a/lib/EasyRdf/Parser/Rdfa.php
+++ b/lib/EasyRdf/Parser/Rdfa.php
@@ -649,11 +649,14 @@ class EasyRdf_Parser_Rdfa extends EasyRdf_Parser
                 print "Document was parsed as HTML.";
         }
 
-        // Establish the base
-        # FIXME: only do this if document is XHTML
+        // Establish the base for both XHTML and HTML documents.
         $xpath = new DOMXPath($doc);
         $xpath->registerNamespace('xh', "http://www.w3.org/1999/xhtml");
         $nodeList = $xpath->query('/xh:html/xh:head/xh:base');
+        if ($node = $nodeList->item(0) and $href = $node->getAttribute('href')) {
+            $this->_baseUri = new EasyRdf_ParsedUri($href);
+        }
+        $nodeList = $xpath->query('/html/head/base');
         if ($node = $nodeList->item(0) and $href = $node->getAttribute('href')) {
             $this->_baseUri = new EasyRdf_ParsedUri($href);
         }


### PR DESCRIPTION
loadXML() chokes on non-valid XML, and as a result easyrdf doesn't return any triple nor any error message explaining what happened, this currently happens with Drupal 8 HTML5 output, see <a href="http://files.openspring.net/tmp/d8-rdfa/Drupal_rdf_Tests_RdfaMarkupTest-3.html">example HTML</a> and its <a href="http://easyrdf-converter.aelius.com/?data=&uri=http%3A%2F%2Ffiles.openspring.net%2Ftmp%2Fd8-rdfa%2FDrupal_rdf_Tests_RdfaMarkupTest-3.html&input_format=guess&output_format=turtle">empty output on the easyrdf converter service</a>. (In this particular case, this HTML is not valid XML due to `&nbsp;` entities. I propose to fall back on the more lenient loadHTML() when loadXM() fails. 

I've also added a more generic support for extracting the base for HTML and XHTML documents. I tried putting  the XML xpath in the loadXML hunk and the HTML xpath in the loadHTML hunk, but I found that for some cases where HTML5 documents were parsed as XML (needed for xmlns: support in HTML5), the HTML xpath was needed as well. So I believe the base extraction should live outside the respective parsing code hunks, and instead both xpath should be ran (they are very fast in comparison to the loadXML/loadHTML).

A side effect of this change is that it now brings the RDFa HTML test suite results on par with the XHTML results :)
