### PR TITLE
Add missing support for empty @datatype in step 11 (test 0317)

### DIFF
--- a/lib/EasyRdf/Parser/Rdfa.php
+++ b/lib/EasyRdf/Parser/Rdfa.php
@@ -496,6 +496,8 @@ class EasyRdf_Parser_Rdfa extends EasyRdf_Parser
                 } elseif ($node->hasAttribute('datetime')) {
                     $value['value'] = $node->getAttribute('datetime');
                     $datetime = TRUE;
+                } elseif ($datatype === '') {
+                    $value['value'] = $node->textContent;
                 } elseif ($datatype === self::RDF_XML_LITERAL) {
                     $value['value'] = '';
                     foreach ($node->childNodes as $child) {


### PR DESCRIPTION
The following sub step was missing from the RDFa parser:
 otherwise, as a plain literal if @datatype is present but has an empty value according to the section on CURIE and IRI Processing. 

I've also added a new test 0317 to the RDFa test suite to cover this bug.

http://easyrdf-converter.aelius.com/ will need to update to reflect this change
