### PR TITLE
enabled travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ index.html
 lib/arc/
 reports
 *.tar.gz
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+#
+# .travis.yml - configuration file for the travis continuous integration service
+#
+# see http://about.travis-ci.org/docs/user/languages/php for more hints
+#
+language: php
+
+php:
+  - 5.3
+  - 5.4
+
+before_install:
+  - wget http://getcomposer.org/composer.phar
+  - composer install --dev
+  - git submodule update --init --recursive
+  - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
+
+script:
+  - make lint
+  - make check-fixme
+  - make check-whitespace
+  - phpunit --configuration phpunit.travis.xml
+  - output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 lib); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
+
+notifications:
+  irc: "irc.freenode.org#easyrdf"
+  email: false

--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,12 @@ clean:
 # TARGET:check-fixme         Scan for files containing the words TODO or FIXME
 .PHONY: check-fixme
 check-fixme:
-	@git grep -n -E 'FIXME|TODO' || echo "No FIXME or TODO lines found."
+	@git grep -n -E 'FIXME|TODO' -- *.php || echo "No FIXME or TODO lines found."; exit 0;
 
 # TARGET:check-whitespace    Scan for files with trailing whitespace
 .PHONY: check-whitespace
 check-whitespace:
-	@git grep -n -E '[ 	]+$$' || echo "No trailing whitespace found."
+	@git grep -n -E '[ 	]+$$' -- *.php || echo "No trailing whitespace found."; exit 0;
 
 # TARGET:help                You're looking at it!
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-EasyRdf
+EasyRdf [![Build Status](https://travis-ci.org/njh/easyrdf.png?branch=master)](https://travis-ci.org/njh/easyrdf)
 =======
 EasyRdf is a PHP library designed to make it easy to consume and produce [RDF].
 It was designed for use in mixed teams of experienced and inexperienced RDF

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,12 @@
     "require": {
         "php": ">=5.2.8"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/njh/easyrdf"
-        }
-    ],
+    "require-dev": {
+        "phpunit/PHPUnit": ">=3.5.15"
+    },
     "autoload": {
-        "psr-0": { "EasyRdf": "lib/" }
+        "psr-0": {
+            "EasyRdf_": "lib/"
+        }
     }
 }

--- a/phpunit.travis.xml
+++ b/phpunit.travis.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    strict="true"
+    syntaxCheck="false"
+    verbose="false"
+    bootstrap="./test/TestHelper.php">
+
+    <testsuites>
+        <testsuite name="EasyRdf Test Suite">
+            <directory suffix="Test.php">./test/EasyRdf/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./lib/EasyRdf/</directory>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text" target="php://stdout" />
+    </logging>
+</phpunit>


### PR DESCRIPTION
Results first:
http://travis-ci.org/jakoch/easyrdf/builds/3923838
This is the Travis report for my fork of EasyRdf.

If you pull this request, you need to register an account on travis-ci.org and fetch the api-token.
With the token you can setup the travis-hook for your njh/easyrdf repository on github manually.

This enables automatic runs of the EasyRdf TestSuite, when 
a) you push 
b) a new pull-request is incomming.
(So you can see, if the PR breaks something, before actually merging it.)
The travis details are attached to the pull-request comment on Github, you might have seen that before. Also the travis-ci bot sends the short-report to #easyrdf on freenode.

List of Changes:
- added composer "vendor" folder to .gitignore
- added phpunit.travis.xml
- enable coverage reporting via logger in phpunit.travis.xml
- removed "repositories" section from composer.json. that would mean that easyrdf has a 3th party vcs repository dependency to easyrdf itself (if added in the "required" section).
- adding travis build status of master branch to readme.md
- added fetching and exec of composer
- added fetching and exec of php-cs-fixer for PSR2 checks
- modified makefile to not run lint on the makefile itself, only on php files.
  used "--" = end of options; "*.php" glob
  got this from http://www.kernel.org/pub/software/scm/git/docs/git-grep.html
- modified makefile to "always terminate successfully", when running tasks "check-whitespace" and "check-fixme". without exit code travis will run forever.
- added make lint, check-whitespace and check-fixme to travis.yml
- added development dependency "phpunit" ">=3.5.15" to composer.json (this will use phpunit 3.7.*)
- added irc-bot reporting to #easyrdf on freenode
- added underscore to PSR-0 prefix
