### PR TITLE
Avoid duplicate Content-Length header

### DIFF
--- a/lib/EasyRdf/GraphStore.php
+++ b/lib/EasyRdf/GraphStore.php
@@ -116,7 +116,6 @@ class EasyRdf_GraphStore
         $client->setMethod($method);
         $client->setRawData($data);
         $client->setHeaders('Content-Type', $mimeType);
-        $client->setHeaders('Content-Length', strlen($data));
         $response = $client->request();
         if (!$response->isSuccessful()) {
             throw new EasyRdf_Exception(


### PR DESCRIPTION
The Content-Length header is already set by the Http_Client during request. The duplicity avoid Sesame compatibilty (Bad Request 500 error)
