### PR TITLE
More characters are needed for guessing RDFXML format

### DIFF
--- a/lib/EasyRdf/Format.php
+++ b/lib/EasyRdf/Format.php
@@ -246,8 +246,8 @@ class EasyRdf_Format
             }
         }
 
-        // Then try and guess by the first 255 bytes of content
-        $short = substr($data, 0, 255);
+        // Then try and guess by the first 1024 bytes of content
+        $short = substr($data, 0, 1024);
         if (preg_match("/^\s*\{/", $short)) {
             return self::getFormat('json');
         } elseif (preg_match("/<rdf:/i", $short)) {

--- a/test/fixtures/foaf.rdf
+++ b/test/fixtures/foaf.rdf
@@ -1,9 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:foaf="http://xmlns.com/foaf/0.1/"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
->
+<!-- This is the FOAF formal vocabulary description, expressed using W3C RDFS and OWL markup. foaf/spec version -->
+<!-- For more information about FOAF:                                            -->
+<!--   see the FOAF project homepage, http://www.foaf-project.org/               -->
+<!--   FOAF specification, http://xmlns.com/foaf/spec/                             -->
+<!--                                                                             -->
+<!-- first we introduce a number of RDF namespaces we will be using... -->
+<rdf:RDF 
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" 
+	xmlns:owl="http://www.w3.org/2002/07/owl#" 
+	xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#" 
+	xmlns:foaf="http://xmlns.com/foaf/0.1/" 
+	xmlns:wot="http://xmlns.com/wot/0.1/" 
+	xmlns:dc="http://purl.org/dc/elements/1.1/">
   <foaf:PersonalProfileDocument rdf:about="">
     <rdfs:label>Joe Bloggs' FOAF File</rdfs:label>
     <foaf:maker rdf:resource="http://www.example.com/joe#me" />


### PR DESCRIPTION
FOAF schema file found at http://xmlns.com/foaf/spec/index.rdf has a long comments preface,
which doesn't fit in 255 characters. 1024 does the trick though, so I changed the buffer size
and altered corresponding test
