### PR TITLE
add a getGraph method to EasyRdf_Resource

### DIFF
--- a/lib/EasyRdf/Resource.php
+++ b/lib/EasyRdf/Resource.php
@@ -79,6 +79,16 @@ class EasyRdf_Resource
         }
     }
 
+    /**
+     * Return the graph that this resource belongs to
+     *
+     * @return EasyRdf_Graph
+     */
+    public function getGraph()
+    {
+        return $this->graph;
+    }
+
     /** Returns the URI for the resource.
      *
      * @return string  URI of this resource.


### PR DESCRIPTION
Hi,

We are developping a project wich make a massive use of EasyRdf. In a lot of cases we got a Resource without the Graph, and we needed to add some BNode as new properties of the Resource.

To create these BNode we had to access to the belonging Graph. So we created getGraph() method in EasyRdf_Resource.
