### PR TITLE
Open serialization API

### DIFF
--- a/lib/EasyRdf/Serialiser/Turtle.php
+++ b/lib/EasyRdf/Serialiser/Turtle.php
@@ -103,8 +103,8 @@ class EasyRdf_Serialiser_Turtle extends EasyRdf_Serialiser
                     return sprintf('%s^^%s', $quoted, $short);
                 }
             } else {
-                $datatypeUri = str_replace('>', '\\>', $datatype);
-                return sprintf('%s^^<%s>', $quoted, $datatypeUri);
+                $encoded_type_iri = self::encodeResourceIRI($datatype);
+                return sprintf('%s^^%s', $quoted, $encoded_type_iri);
             }
         } elseif ($lang = $literal->getLang()) {
             return $quoted . '@' . $lang;
@@ -201,7 +201,7 @@ class EasyRdf_Serialiser_Turtle extends EasyRdf_Serialiser
                     $pStr = $short;
                 }
             } else {
-                $pStr = '<'.str_replace('>', '\\>', $property).'>';
+                $pStr = self::encodeResourceIRI($property);
             }
 
             if ($pCount) {


### PR DESCRIPTION
`EasyRdf_Serialiser_Turtle` class has encoding methods, which are useful in other scenarios (such as SPARQL-queries generation). Unfortunately, all of it's internal mechanics is `protected` while some of the methods could be `public static`
- `serialiseResource()` could be splitted in 2 methods. one to get string-representation and another to actually encode it (braces, escaping)
- `quotedString()` is useful as is. just make it `public static`
- `serialiseObject()` would be useful as `public static` method of its own but extracting part about literals into separate method(s) would make sense too

would you accept this as a patch? :)
