### PR TITLE
content attribute takes priority over the datetime attribute in RDFa

### DIFF
--- a/lib/EasyRdf/Parser/Rdfa.php
+++ b/lib/EasyRdf/Parser/Rdfa.php
@@ -518,20 +518,20 @@ class EasyRdf_Parser_Rdfa extends EasyRdf_Parser
                     $datatype = $this->processUri($node, $context, $datatype, true);
                 }
 
-                if ($node->nodeName === 'data' and $node->hasAttribute('value')) {
+                if ($content !== null) {
+                    $value['value'] = $content;
+                } elseif ($node->nodeName === 'data' and $node->hasAttribute('value')) {
                     $value['value'] = $node->getAttribute('value');
                 } elseif ($node->hasAttribute('datetime')) {
                     $value['value'] = $node->getAttribute('datetime');
                     $datetime = true;
-                } elseif ($datatype === '' && $content === null) {
+                } elseif ($datatype === '') {
                     $value['value'] = $node->textContent;
-                } elseif ($datatype === self::RDF_XML_LITERAL && $content === null) {
+                } elseif ($datatype === self::RDF_XML_LITERAL) {
                     $value['value'] = '';
                     foreach ($node->childNodes as $child) {
                         $value['value'] .= $child->C14N();
                     }
-                } elseif ($content !== null) {
-                    $value['value'] = $content;
                 } elseif (is_null($datatype) and empty($rel) and empty($rev)) {
                     $value['value'] = $this->getUriAttribute(
                         $node,


### PR DESCRIPTION
This change in RDFa was decided shortly after the release of EasyRdf beta1: https://github.com/rdfa/rdfa-website/commit/d4efc1383097aab06953beba9e1af826e6203b03

While fixing this, I notice it require another `$content === null` to be added to the step 11, which included quite a few of these already. I decided to move the content attribute processing higher up to avoid repeating these `$content === null`.
