### PR TITLE
Add JSON-LD parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,8 @@
         "irc": "irc://chat.freenode.net/easyrdf"
     },
     "require": {
-        "php": ">=5.2.8"
-    },
-    "suggest": {
-        "ml/json-ld": "dev-master"
+        "php": ">=5.2.8",
+        "ml/json-ld": "1.*"
     },
     "require-dev": {
         "phpunit/PHPUnit": ">=3.5.15",

--- a/lib/EasyRdf/Format.php
+++ b/lib/EasyRdf/Format.php
@@ -542,6 +542,16 @@ EasyRdf_Format::register(
 );
 
 EasyRdf_Format::register(
+    'jsonld',
+    'JSON-LD',
+    'http://www.w3.org/TR/json-ld/',
+    array(
+        'application/ld+json' => 1.0
+    ),
+    array('jsonld')
+);
+
+EasyRdf_Format::register(
     'ntriples',
     'N-Triples',
     'http://www.w3.org/TR/n-triples/',
@@ -668,6 +678,7 @@ EasyRdf_Format::register(
 */
 
 EasyRdf_Format::registerParser('json', 'EasyRdf_Parser_Json');
+EasyRdf_Format::registerParser('jsonld', 'EasyRdf_Parser_JsonLd');
 EasyRdf_Format::registerParser('ntriples', 'EasyRdf_Parser_Ntriples');
 EasyRdf_Format::registerParser('php', 'EasyRdf_Parser_RdfPhp');
 EasyRdf_Format::registerParser('rdfxml', 'EasyRdf_Parser_RdfXml');

--- a/lib/EasyRdf/Parser/JsonLd.php
+++ b/lib/EasyRdf/Parser/JsonLd.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * EasyRdf
+ *
+ * LICENSE
+ *
+ * Copyright (c) 2009-2013 Nicholas J Humfrey.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author 'Nicholas J Humfrey" may be used to endorse or
+ *    promote products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    EasyRdf
+ * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
+ * @license    http://www.opensource.org/licenses/bsd-license.php
+ */
+
+if (PHP_MAJOR_VERSION > 5 or (PHP_MAJOR_VERSION == 5 and PHP_MINOR_VERSION >= 3)) {
+    require dirname(__FILE__).'/JsonLdImplementation.php';
+} else {
+    throw new LogicException("JSON-LD support requires PHP 5.3+");
+}

--- a/lib/EasyRdf/Parser/JsonLdImplementation.php
+++ b/lib/EasyRdf/Parser/JsonLdImplementation.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * EasyRdf
+ *
+ * LICENSE
+ *
+ * Copyright (c) 2009-2013 Nicholas J Humfrey.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author 'Nicholas J Humfrey" may be used to endorse or
+ *    promote products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    EasyRdf
+ * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
+ * @license    http://www.opensource.org/licenses/bsd-license.php
+ */
+
+/**
+ * Class to parse JSON-LD to an EasyRdf_Graph
+ *
+ * @package    EasyRdf
+ * @copyright  Copyright (c) 2014 Markus Lanthaler
+ * @author     Markus Lanthaler <mail@markus-lanthaler.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php
+ */
+class EasyRdf_Parser_JsonLd extends EasyRdf_Parser
+{
+    /**
+      * Parse a JSON-LD document into an EasyRdf_Graph
+      *
+      * Attention: Since JSON-LD supports datasets, a document may contain
+      * multiple graphs and not just one. This parser returns only the
+      * default graph. An alternative would be to merge all graphs.
+      *
+      * @param object EasyRdf_Graph $graph   the graph to load the data into
+      * @param string               $data    the RDF document data
+      * @param string               $format  the format of the input data
+      * @param string               $baseUri the base URI of the data being parsed
+      * @return integer             The number of triples added to the graph
+      */
+    public function parse($graph, $data, $format, $baseUri)
+    {
+        parent::checkParseParams($graph, $data, $format, $baseUri);
+
+        if ($format != 'jsonld') {
+            throw new EasyRdf_Exception(
+                "EasyRdf_Parser_JsonLd does not support $format"
+            );
+        }
+
+        try {
+            $quads = \ML\JsonLD\JsonLD::toRdf($data, array('base' => $baseUri));
+        } catch (\ML\JsonLD\Exception\JsonLdException $e) {
+            throw new EasyRdf_Parser_Exception($e->getMessage());
+        }
+
+        foreach ($quads as $quad) {
+            // Ignore named graphs
+            if (null !== $quad->getGraph()) {
+                continue;
+            }
+
+            $subject = (string) $quad->getSubject();
+            if ('_:' === substr($subject, 0, 2)) {
+                $subject = $this->remapBnode($subject);
+            }
+
+            $predicate = (string) $quad->getProperty();
+
+            if ($quad->getObject() instanceof ML\IRI\IRI) {
+                $object = array(
+                    'type' => 'uri',
+                    'value' => (string) $quad->getObject()
+                );
+
+                if ('_:' === substr($object['value'], 0, 2)) {
+                    $object = array(
+                        'type' => 'bnode',
+                        'value' => $this->remapBnode($object['value'])
+                    );
+                }
+            } else {
+                $object = array(
+                    'type' => 'literal',
+                    'value' => $quad->getObject()->getValue()
+                );
+
+                if ($quad->getObject() instanceof \ML\JsonLD\LanguageTaggedString) {
+                    $object['lang'] = $quad->getObject()->getLanguage();
+                } else {
+                    $object['datatype'] = $quad->getObject()->getType();
+                }
+            }
+
+            $this->addTriple($subject, $predicate, $object);
+        }
+
+        return $this->tripleCount;
+    }
+}

--- a/test/EasyRdf/Parser/JsonLdTest.php
+++ b/test/EasyRdf/Parser/JsonLdTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * EasyRdf
+ *
+ * LICENSE
+ *
+ * Copyright (c) 2009-2013 Nicholas J Humfrey.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author 'Nicholas J Humfrey" may be used to endorse or
+ *    promote products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    EasyRdf
+ * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
+ * @license    http://www.opensource.org/licenses/bsd-license.php
+ */
+
+require_once dirname(dirname(dirname(__FILE__))).
+             DIRECTORY_SEPARATOR.'TestHelper.php';
+
+/**
+ * JSON-LD parsing tests
+ *
+ * @package    EasyRdf
+ * @copyright  Copyright (c) 2014 Markus Lanthaler
+ * @author     Markus Lanthaler <mail@markus-lanthaler.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php
+ */
+class EasyRdf_Parser_JsonLdTest extends EasyRdf_TestCase
+{
+    /** @var EasyRdf_Parser_JsonLd */
+    protected $parser = null;
+
+    /** @var EasyRdf_Graph */
+    protected $graph = null;
+
+    public function setUp()
+    {
+        if (PHP_MAJOR_VERSION < 5 or (PHP_MAJOR_VERSION == 5 and PHP_MINOR_VERSION < 3)) {
+            $this->markTestSkipped("JSON-LD support requires PHP 5.3+");
+        }
+
+        $this->graph = new EasyRdf_Graph();
+        $this->parser = new EasyRdf_Parser_JsonLd();
+    }
+
+    public function testParse()
+    {
+        $data = readFixture('foaf.jsonld');
+        $count = $this->parser->parse($this->graph, $data, 'jsonld', null);
+        $this->assertSame(14, $count);
+
+        $joe = $this->graph->resource('http://www.example.com/joe#me');
+        $this->assertNotNull($joe);
+        $this->assertClass('EasyRdf_Resource', $joe);
+        $this->assertSame('http://www.example.com/joe#me', $joe->getUri());
+
+        $name = $joe->get('foaf:name');
+        $this->assertNotNull($name);
+        $this->assertClass('EasyRdf_Literal', $name);
+        $this->assertSame('Joe Bloggs', $name->getValue());
+        $this->assertSame('en', $name->getLang());
+        $this->assertSame(null, $name->getDatatype());
+
+        $project = $joe->get('foaf:currentProject');
+        $this->assertNotNull($project);
+        $this->assertClass('EasyRdf_Resource', $project);
+        $this->assertSame('_:genid1', $project->getUri());
+    }
+
+    public function testParseWithFormatObject()
+    {
+        $data = readFixture('foaf.jsonld');
+        $format = EasyRdf_Format::getFormat('jsonld');
+        $count = $this->parser->parse($this->graph, $data, $format, null);
+        $this->assertSame(14, $count);
+
+        $joe = $this->graph->resource('http://www.example.com/joe#me');
+        $this->assertStringEquals('Joe Bloggs', $joe->get('foaf:name'));
+    }
+
+    public function testParseJsonSyntaxError()
+    {
+        $this->setExpectedException(
+            'EasyRdf_Parser_Exception',
+            'Syntax error, malformed JSON.'
+        );
+
+        $this->parser->parse(
+            $this->graph,
+            '{ "foo":"bar"',
+            'jsonld',
+            'http://www.example.com/'
+        );
+    }
+
+    public function testParseEmpty()
+    {
+        $count = $this->parser->parse($this->graph, '{}', 'jsonld', null);
+        $this->assertSame(0, $count);
+
+        // Should be empty but no exception thrown
+        $this->assertSame(0, $this->graph->countTriples());
+    }
+
+    public function testParseUnsupportedFormat()
+    {
+        $this->setExpectedException(
+            'EasyRdf_Exception',
+            'EasyRdf_Parser_JsonLd does not support unsupportedformat'
+        );
+        $rdf = $this->parser->parse(
+            $this->graph,
+            null,
+            'unsupportedformat',
+            null
+        );
+    }
+}

--- a/test/fixtures/foaf.jsonld
+++ b/test/fixtures/foaf.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "http://xmlns.com/foaf/0.1/",
+    "label": "http://www.w3.org/2000/01/rdf-schema#label",
+    "homepage": { "@type": "@id" },
+    "maker": { "@type": "@id" }
+  },
+  "@id": "http://www.example.com/joe/foaf.rdf",
+  "@type": "PersonalProfileDocument",
+  "label": "Joe Bloggs' FOAF File",
+  "maker": "http://www.example.com/joe#me",
+  "primaryTopic": {
+    "@id": "http://www.example.com/joe#me",
+    "@type": "Person",
+    "title": "Mr",
+    "firstName" : "Joe",
+    "family_name" : "Bloggs",
+    "name": { "@value": "Joe Bloggs", "@language": "en" },
+    "homepage": "http://www.example.com/joe/",
+    "currentProject" : {
+      "@type": "Project",
+      "homepage": "http://www.example.com/project",
+      "name": "Joe's Current Project"
+    }
+  }
+}


### PR DESCRIPTION
Please note that JSON-LD is a dataset format and thus a file might contain multiple graphs. Since easyrdf doesn't support datasets AFAICT, this parser just returns the default graph and ignores all named graphs.

This closes #87.
