### PR TITLE
Allow sendGraph to "default" graph

### DIFF
--- a/lib/EasyRdf/GraphStore.php
+++ b/lib/EasyRdf/GraphStore.php
@@ -107,7 +107,7 @@ class EasyRdf_GraphStore
         $mimeType = $formatObj->getDefaultMimeType();
 
         $graphUri = $this->parsedUri->resolve($uriRef)->toString();
-        $dataUrl = $this->urlForGraph($graphUri);
+        $dataUrl = $dataUrl==="default" ? $dataUrl : $this->urlForGraph($graphUri);
 
         $client = EasyRdf_Http::getDefaultHttpClient();
         $client->resetParameters(true);


### PR DESCRIPTION
A quick fix to allow to use GraphStore sendGraph function with "default" graph.

Would it be more coherent to use "default" only when providing a NULL $uriRef to GraphStore insert function?, currently the $uriRef is replaced with the result of getUri() (line 99 of GraphStore) ? 
