### PR TITLE
Skip JSON-LD parser test when missing library

### DIFF
--- a/test/EasyRdf/Parser/JsonLdTest.php
+++ b/test/EasyRdf/Parser/JsonLdTest.php
@@ -60,6 +60,10 @@ class EasyRdf_Parser_JsonLdTest extends EasyRdf_TestCase
             $this->markTestSkipped("JSON-LD support requires PHP 5.3+");
         }
 
+        if (!class_exists('\ML\JsonLD\JsonLD')) {
+            $this->markTestSkipped('"ml/json-ld" dependency is not installed');
+        }
+
         $this->graph = new EasyRdf_Graph();
         $this->parser = new EasyRdf_Parser_JsonLd();
     }


### PR DESCRIPTION
Right now, one of the tests doesn't check if the library is actually installed, so it errors out.
