### PR TITLE
use locale-independent format specifier for formatting priority values i...

### DIFF
--- a/lib/EasyRdf/Format.php
+++ b/lib/EasyRdf/Format.php
@@ -107,7 +107,7 @@ class EasyRdf_Format
             if ($q == 1.0) {
                 $acceptStr .= $type;
             } else {
-                $acceptStr .= sprintf("%s;q=%1.1f", $type, $q);
+                $acceptStr .= sprintf("%s;q=%1.1F", $type, $q);
             }
         }
         return $acceptStr;


### PR DESCRIPTION
I'm using the locales fi_FI.UTF-8 and sv_SE.UTF-8. In these locales a comma is used as decimal separator. This causes problems with the getHttpAcceptHeader method, which will then return a value such as this:

```
application/x-httpd-php-source,application/n-triples,application/ntriples;q=0,9,application/x-ntriples;q=0,9,text/ntriples;q=0,9,text/plain;q=0,9,application/rdf+xml;q=0,8,text/turtle;q=0,8,application/turtle;q=0,7,application/x-turtle;q=0,7,application/xhtml+xml;q=0,4,text/html;q=0,4
```

Notice that commas are used in the priority values, which of course violates the spec for Accept headers.
This is possibly related to issue #203 (could be the cause for that problem, but hard to know for sure).

I'd have written a test case to check for this, but I couldn't think of a way to write a locale-dependent test. The test would have to guess a suitable locale that a) uses comma as decimal separator and b) exists on the system running the tests, and set LC_NUMERIC to that locale name. Seems pretty difficult to do that.

This patch fixes the sprintf call in getHttpAcceptHeader to use a locale-independent format specifier F (exists since 5.0.3). See http://php.net/manual/en/function.sprintf.php
