### PR TITLE
Fix potential bugs and incomplete docs

### DIFF
--- a/lib/Isomorphic.php
+++ b/lib/Isomorphic.php
@@ -99,7 +99,7 @@ class Isomorphic
         if ($groundedStatementsMatch === false) {
             // The grounded statements do not match
             return null;
-        } elseif (count($bnodesA) > 0 or count($bnodesB > 0)) {
+        } elseif (count($bnodesA) > 0 or count($bnodesB) > 0) {
             // There are blank nodes - build a bi-jection
             return self::buildBijectionTo($statementsA, $bnodesA, $statementsB, $bnodesB);
         } else {

--- a/lib/Parser/RdfPhp.php
+++ b/lib/Parser/RdfPhp.php
@@ -61,7 +61,7 @@ class RdfPhp extends Parser
      * Parse RDF/PHP into an EasyRdf\Graph
      *
      * @param Graph  $graph   the graph to load the data into
-     * @param string $data    the RDF document data
+     * @param array[] $data   the RDF document data
      * @param string $format  the format of the input data
      * @param string $baseUri the base URI of the data being parsed
      *

--- a/lib/Serialiser/Turtle.php
+++ b/lib/Serialiser/Turtle.php
@@ -93,7 +93,7 @@ class Turtle extends Serialiser
      * be written to a Turtle document. URIs will be shortened into CURIES
      * where possible.
      *
-     * @param  Resource $resource        The resource to convert to a Turtle string
+     * @param  Resource|string $resource The resource to convert to a Turtle string
      * @param  boolean $createNamespace  If true, a new namespace may be created
      *
      * @return string

--- a/lib/Sparql/Client.php
+++ b/lib/Sparql/Client.php
@@ -312,7 +312,7 @@ class Client
             return $data->serialise('ntriples');
         } else {
             throw new Exception(
-                "Don't know how to convert to triples for SPARQL query: ".$response->getBody()
+                "Don't know how to convert to triples for SPARQL query"
             );
         }
     }


### PR DESCRIPTION
This is split from #223 to make it easier to review.
- Fixes broken `count` in `Isomorphic`.
- Removes copy-pasta in `Client`.
- Fixes incomplete type hints in PHPDocs.

Most issues found with the static code analysis in PHPStorm.
