### PR TITLE
v0.9.x compatible version of HTTP timeout fix. Fixes #202

### DIFF
--- a/lib/EasyRdf/Http/Client.php
+++ b/lib/EasyRdf/Http/Client.php
@@ -422,7 +422,9 @@ class EasyRdf_Http_Client
             if (!$socket) {
                 throw new EasyRdf_Exception("Unable to connect to $host:$port ($errstr)");
             }
-
+            stream_set_timeout($socket, $this->config['timeout']);
+            $info = stream_get_meta_data($socket);
+            
             // Write the request
             $path = $uri['path'];
             if (empty($path)) {
@@ -447,8 +449,13 @@ class EasyRdf_Http_Client
 
             // Read in the response
             $content = '';
-            while (!feof($socket)) {
+            while (!feof($socket) && !$info['timed_out']) {
                 $content .= fgets($socket);
+                $info = stream_get_meta_data($socket);
+            }
+
+            if ($info['timed_out']) {
+                throw new EasyRdf_Exception("Request to $host:$port timed out");
             }
 
             // FIXME: support HTTP/1.1 100 Continue


### PR DESCRIPTION
The same code as in #234 but adapted for 0.9.x.