### PR TITLE
Extend getDatatypeForValue with xsd:string

### DIFF
--- a/lib/Literal.php
+++ b/lib/Literal.php
@@ -191,6 +191,8 @@ class Literal
             return 'http://www.w3.org/2001/XMLSchema#boolean';
         } elseif (is_object($value) and $value instanceof \DateTime) {
             return 'http://www.w3.org/2001/XMLSchema#dateTime';
+        } elseif (is_string($value)) {
+            return 'http://www.w3.org/2001/XMLSchema#string';
         } else {
             return null;
         }


### PR DESCRIPTION
I extended **\EasyRdf\Literal.php**'s function **getDatatypeForValue** with an additional check for strings (xsd:string).