### PR TITLE
Implement the ArrayAccess Interface in Resource

### DIFF
--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -43,7 +43,7 @@ namespace EasyRdf;
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-class Resource
+class Resource implements \ArrayAccess
 {
     /** The URI for this resource */
     protected $uri = null;
@@ -753,5 +753,76 @@ class Resource
     public function __unset($name)
     {
         return $this->graph->delete($this->uri, $name);
+    }
+
+    /**
+     * Whether a offset exists
+     *
+     * The return value will be casted to boolean if non-boolean was returned.
+     *
+     * Example:
+     *   if(isset($resource['rdfs:label'])) { }
+     *
+     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     *
+     * @param mixed $offset An offset to check for.
+     *
+     * @return boolean true on success or false on failure.
+     */
+    public function offsetExists($offset)
+    {
+        return $this->__isset($offset);
+    }
+
+    /**
+     * Offset to retrieve
+     *
+     * Example:
+     *   $label = $resource['rdfs:label'];
+     *
+     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     *
+     * @param mixed $offset The offset to retrieve.
+     *
+     * @return mixed Can return all value types.
+     */
+    public function offsetGet($offset)
+    {
+        return $this->__get($offset);
+    }
+
+    /**
+     * Offset to set
+     *
+     * Example:
+     *   $resource['rdfs:label'] = 'label';
+     *
+     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     *
+     * @param mixed The offset to assign the value to.
+     * @param mixed $value The value to set.
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->__set($offset, $value);
+    }
+
+    /**
+     * Offset to unset
+     *
+     * Example:
+     *   unset($resource['rdfs:label']);
+     *
+     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     *
+     * @param mixed $offset  The offset to unset.
+     *
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        $this->__unset($offset);
     }
 }

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -1296,8 +1296,8 @@ class ResourceTest extends TestCase
         $this->setupTestGraph();
         $this->resource['rdf:testOffsetSet'] = 'testOffsetSet';
         $this->assertStringEquals(
-          'testOffsetSet',
-          $this->resource->get('rdf:testOffsetSet')
+            'testOffsetSet',
+            $this->resource->get('rdf:testOffsetSet')
         );
     }
 
@@ -1307,8 +1307,8 @@ class ResourceTest extends TestCase
         $this->resource->add('rdf:testOffsetUnset', 'testOffsetUnset');
         unset($this->resource['rdf:testMagicUnset']);
         $this->assertStringEquals(
-          null,
-          $this->resource->get('rdf:testMagicUnset')
+            null,
+            $this->resource->get('rdf:testMagicUnset')
         );
     }
 }

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -1291,6 +1291,15 @@ class ResourceTest extends TestCase
         $this->assertStringEquals('testOffsetGet', $this->resource['rdf:testOffsetGet']);
     }
 
+    public function testOffsetGetNonExistent()
+    {
+        $this->setupTestGraph();
+        $this->assertStringEquals(
+          null,
+          $this->resource['rdf:foobar']
+        );
+    }
+
     public function testOffsetSet()
     {
         $this->setupTestGraph();

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -1295,8 +1295,8 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         $this->assertStringEquals(
-          null,
-          $this->resource['rdf:foobar']
+            null,
+            $this->resource['rdf:foobar']
         );
     }
 

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -1274,4 +1274,41 @@ class ResourceTest extends TestCase
             $this->resource->get('rdf:testMagicUnset')
         );
     }
+
+    public function testOffsetExists()
+    {
+        $this->setupTestGraph();
+        $this->assertFalse(isset($this->resource['rdf:testOffsetExists']));
+        $this->resource->add('rdf:testOffsetExists', 'testOffsetExists');
+        $this->assertTrue(isset($this->resource['rdf:testOffsetExists']));
+    }
+
+    public function testOffsetGet()
+    {
+        $this->setupTestGraph();
+        $this->assertStringEquals(null, $this->resource['rdf:testOffsetGet']);
+        $this->resource->add('rdf:testOffsetGet', 'testOffsetGet');
+        $this->assertStringEquals('testOffsetGet', $this->resource['rdf:testOffsetGet']);
+    }
+
+    public function testOffsetSet()
+    {
+        $this->setupTestGraph();
+        $this->resource['rdf:testOffsetSet'] = 'testOffsetSet';
+        $this->assertStringEquals(
+          'testOffsetSet',
+          $this->resource->get('rdf:testOffsetSet')
+        );
+    }
+
+    public function testOffsetUnset()
+    {
+        $this->setupTestGraph();
+        $this->resource->add('rdf:testOffsetUnset', 'testOffsetUnset');
+        unset($this->resource['rdf:testMagicUnset']);
+        $this->assertStringEquals(
+          null,
+          $this->resource->get('rdf:testMagicUnset')
+        );
+    }
 }


### PR DESCRIPTION
We are developing a full stack framework to consume triple store data in Symfony2 applications. We use massively EasyRdf to manage resources.

In order to use resources in twig template we need to implement ArrayAccess interface. With this update we can use the resource in template like :

```twig
<h1>{{ resource['rdfs:label'] }}</h1>
```