### PR TITLE
Setting an alternate default resource class

### DIFF
--- a/lib/Graph.php
+++ b/lib/Graph.php
@@ -182,7 +182,7 @@ class Graph
         ) {
             return 'EasyRdf\Collection';
         }
-        return 'EasyRdf\Resource';
+        return TypeMapper::getDefaultResourceClass();
     }
 
     /**

--- a/lib/TypeMapper.php
+++ b/lib/TypeMapper.php
@@ -48,6 +48,9 @@ class TypeMapper
     /** The type map registry */
     private static $map = array();
 
+    /** Default resource class */
+    private static $defaultResourceClass = 'EasyRdf\Resource';
+
     /** Get the registered class for an RDF type
      *
      * If a type is not registered, then this method will return null.

--- a/lib/TypeMapper.php
+++ b/lib/TypeMapper.php
@@ -151,7 +151,7 @@ class TypeMapper
         }
 
         $ancestors = class_parents($class);
-        if ( ($class != 'EasyRdf\Resource') && (empty($ancestors) || !in_array('EasyRdf\Resource', $ancestors))) {
+        if (($class != 'EasyRdf\Resource') && (empty($ancestors) || !in_array('EasyRdf\Resource', $ancestors))) {
             throw new \InvalidArgumentException(
                 "Given class should have EasyRdf\\Resource as an ancestor"
             );

--- a/lib/TypeMapper.php
+++ b/lib/TypeMapper.php
@@ -119,6 +119,46 @@ class TypeMapper
             unset(self::$map[$type]);
         }
     }
+
+    /**
+     * @return string           The default Resource class
+     */
+    public static function getDefaultResourceClass()
+    {
+        return self::$defaultResourceClass;
+    }
+
+    /**
+     * Sets the default resource class
+     *
+     * @param  string $class The resource full class name (e.g. \MyCompany\Resource)
+     *
+     * @throws \InvalidArgumentException
+     * @return string           The default Resource class
+     */
+    public static function setDefaultResourceClass($class)
+    {
+        if (!is_string($class) or $class == null or $class == '') {
+            throw new \InvalidArgumentException(
+                "\$class should be a string and cannot be null or empty"
+            );
+        }
+
+        if (!class_exists($class)) {
+            throw new \InvalidArgumentException(
+                "Given class should be an existing class"
+            );
+        }
+
+        $ancestors = class_parents($class);
+        if ( ($class != 'EasyRdf\Resource') && (empty($ancestors) || !in_array('EasyRdf\Resource', $ancestors))) {
+            throw new \InvalidArgumentException(
+                "Given class should have EasyRdf\\Resource as an ancestor"
+            );
+        }
+
+        return self::$defaultResourceClass = $class;
+    }
 }
 
 

--- a/test/EasyRdf/TypeMapperTest.php
+++ b/test/EasyRdf/TypeMapperTest.php
@@ -276,13 +276,17 @@ class TypeMapperTest extends TestCase
         $this->assertClass('EasyRdf\MyTypeClass', $joe);
         $this->assertTrue($joe->myMethod());
 
-        $fooCompany = $graph->resource('http://www.example.com/fooCompany');
+        $joeFoaf = $graph->resource('http://www.example.com/joe/foaf.rdf');
         
-        $this->assertClass('EasyRdf\Resource', $fooCompany);
+        $this->assertClass('EasyRdf\Resource', $joeFoaf);
         
         TypeMapper::setDefaultResourceClass('EasyRdf\MyTypeClass');
-        
-        $joesFoaf = $graph->resource('http://www.example.com/joe#me');
+        $graph = new Graph(
+            'http://www.example.com/joe/foaf.rdf',
+            $data,
+            'json'
+        );
+        $joesFoaf = $graph->resource('http://www.example.com/joe/foaf.rdf');
         $this->assertClass('EasyRdf\MyTypeClass', $joesFoaf);
         $this->assertTrue($joesFoaf->myMethod());
     }

--- a/test/EasyRdf/TypeMapperTest.php
+++ b/test/EasyRdf/TypeMapperTest.php
@@ -275,5 +275,15 @@ class TypeMapperTest extends TestCase
         $joe = $graph->resource('http://www.example.com/joe#me');
         $this->assertClass('EasyRdf\MyTypeClass', $joe);
         $this->assertTrue($joe->myMethod());
+
+        $fooCompany = $graph->resource('http://www.example.com/fooCompany');
+        
+        $this->assertClass('EasyRdf\Resource', $fooCompany);
+        
+        TypeMapper::setDefaultResourceClass('EasyRdf\MyTypeClass');
+        
+        $joesFoaf = $graph->resource('http://www.example.com/joe#me');
+        $this->assertClass('EasyRdf\MyTypeClass', $joesFoaf);
+        $this->assertTrue($joesFoaf->myMethod());
     }
 }

--- a/test/EasyRdf/TypeMapperTest.php
+++ b/test/EasyRdf/TypeMapperTest.php
@@ -212,6 +212,57 @@ class TypeMapperTest extends TestCase
         TypeMapper::delete(array());
     }
 
+    public function testSetNonExtendingDefaultResourceClass()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Given class should have EasyRdf\Resource as an ancestor'
+        );
+        TypeMapper::setDefaultResourceClass('EasyRdf\Graph');
+    }
+
+    public function testSetBaseDefaultResourceClass()
+    {
+        TypeMapper::setDefaultResourceClass('EasyRdf\Resource');
+        $this->assertEquals('EasyRdf\Resource', TypeMapper::getDefaultResourceClass());
+    }
+
+    public function testSetDefaultResourceClass()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Given class should be an existing class'
+        );
+        TypeMapper::setDefaultResourceClass('FooBar\Resource');
+    }
+
+    public function testSetDefaultResourceClassEmptyString()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            '$class should be a string and cannot be null or empty'
+        );
+        TypeMapper::setDefaultResourceClass('');
+    }
+
+    public function testSetDefaultResourceClassNull()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            '$class should be a string and cannot be null or empty'
+        );
+        TypeMapper::setDefaultResourceClass(null);
+    }
+
+    public function testSetDefaultResourceClassNonString()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            '$class should be a string and cannot be null or empty'
+        );
+        TypeMapper::setDefaultResourceClass(array());
+    }
+
     public function testInstantiate()
     {
         TypeMapper::set('foaf:Person', 'EasyRdf\MyTypeClass');

--- a/test/fixtures/foaf.json
+++ b/test/fixtures/foaf.json
@@ -13,12 +13,6 @@
         }
 
       ],
-    "http://xmlns.com/foaf/0.1/member" : [ {
-        "value" : "http://www.example.com/fooCompany",
-        "type" : "uri"
-        }
-
-      ],
     "http://xmlns.com/foaf/0.1/family_name" : [ {
         "value" : "Bloggs",
         "type" : "literal"
@@ -46,21 +40,6 @@
       ],
     "http://xmlns.com/foaf/0.1/title" : [ {
         "value" : "Mr",
-        "type" : "literal"
-        }
-
-      ]
-    }
-  ,
-  "http://www.example.com/fooCompany" : {
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : [ {
-        "value" : "http://xmlns.com/foaf/0.1/Organization",
-        "type" : "uri"
-        }
-
-      ],
-    "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-        "value" : "the Foo Company",
         "type" : "literal"
         }
 

--- a/test/fixtures/foaf.json
+++ b/test/fixtures/foaf.json
@@ -13,6 +13,12 @@
         }
 
       ],
+    "http://xmlns.com/foaf/0.1/member" : [ {
+        "value" : "http://www.example.com/fooCompany",
+        "type" : "uri"
+        }
+
+      ],
     "http://xmlns.com/foaf/0.1/family_name" : [ {
         "value" : "Bloggs",
         "type" : "literal"
@@ -40,6 +46,21 @@
       ],
     "http://xmlns.com/foaf/0.1/title" : [ {
         "value" : "Mr",
+        "type" : "literal"
+        }
+
+      ]
+    }
+  ,
+  "http://www.example.com/fooCompany" : {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" : [ {
+        "value" : "http://xmlns.com/foaf/0.1/Organization",
+        "type" : "uri"
+        }
+
+      ],
+    "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+        "value" : "the Foo Company",
         "type" : "literal"
         }
 


### PR DESCRIPTION
EasyRdf is a central component in the framework we recently released. It does a great work but has some limitations in the usage we make of it. One of the most inconvenient to us is the fact that the base resource can't be easily extended in order to have a default Resource class that would be more adapted to some usages (in our case, the resource class we would like to set is just aware of other objects in the framework)

Here is a proposal of what could be done in order to tell EasyRdf which base Resource class to use when TypeMapper can't find any appropriate class for given type.

If you are ok with this, further tests should be added, in particular a test with a "correct" class.