### PR TITLE
Escaped backslash and unescaped uri

### DIFF
--- a/lib/Parser/Ntriples.php
+++ b/lib/Parser/Ntriples.php
@@ -146,7 +146,7 @@ class Ntriples extends Parser
         } elseif (preg_match('/"(.*)"/', $obj, $matches)) {
             return array('type' => 'literal', 'value' => $this->unescapeString($matches[1]));
         } elseif (preg_match('/<([^<>]+)>/', $obj, $matches)) {
-            return array('type' => 'uri', 'value' => $matches[1]);
+            return array('type' => 'uri', 'value' => $this->unescapeString($matches[1]));
         } elseif (preg_match('/_:([A-Za-z0-9]*)/', $obj, $matches)) {
             if (empty($matches[1])) {
                 return array(

--- a/lib/Serialiser/Ntriples.php
+++ b/lib/Serialiser/Ntriples.php
@@ -129,7 +129,7 @@ class Ntriples extends Serialiser
         } elseif ($no < 92) {
             return $c;                            /* #x23-#x5B (35-91) */
         } elseif ($no == 92) {
-            return '\\';                          /* #x5C (92) */
+            return '\\\\'; // double backslash    /* #x5C (92) */
         } elseif ($no < 127) {
             return $c;                            /* #x5D-#x7E (93-126) */
         } elseif ($no < 65536) {

--- a/test/EasyRdf/Parser/NtriplesTest.php
+++ b/test/EasyRdf/Parser/NtriplesTest.php
@@ -184,6 +184,35 @@ class NtriplesTest extends TestCase
         $this->assertSame("\x0A", $b->getValue());
     }
 
+    public function testParseUnicodeObjectUri()
+    {
+        $count = $this->parser->parse(
+            $this->graph,
+            '<http://example.com/a> <http://example.com/b> <http://example.com/Iv\u00E1n> .',
+            'ntriples',
+            null
+        );
+        $this->assertSame(1, $count);
+
+        $a = $this->graph->resource('http://example.com/a');
+        $b = $a->get('<http://example.com/b>');
+        $this->assertSame("http://example.com/Iván", $b->getUri());
+    }
+
+    public function testParseUnicodeSubjectUri()
+    {
+        $count = $this->parser->parse(
+            $this->graph,
+            '<http://example.com/Iv\u00E1n> <http://example.com/b> <http://example.com/c> .',
+            'ntriples',
+            null
+        );
+        $this->assertSame(1, $count);
+
+        $a = $this->graph->resource('http://example.com/Iván');
+        $this->assertNotNull($a);
+    }
+
     public function testParseUnicode2()
     {
         $count = $this->parser->parse(

--- a/test/EasyRdf/Serialiser/NtriplesTest.php
+++ b/test/EasyRdf/Serialiser/NtriplesTest.php
@@ -193,6 +193,18 @@ class NtriplesTest extends TestCase
         );
     }
 
+    public function testSerialiseBackslash()
+    {
+        $joe = $this->graph->resource('http://www.example.com/joe#me');
+        $joe->set('foaf:nick', '\\backslash');
+        $this->assertSame(
+            "<http://www.example.com/joe#me> ".
+            "<http://xmlns.com/foaf/0.1/nick> ".
+            '"\\\\backslash" .'."\n",
+            $this->serialiser->serialise($this->graph, 'ntriples')
+        );
+    }
+
     public function testSerialiseBNode()
     {
         $joe = $this->graph->resource('http://www.example.com/joe#me');


### PR DESCRIPTION
Escaped backslash in a string while converting to turtle

Unescaped uri while parsing ntripples
Documentation does not say uris are escaped, but uri seems te be escaped on serialising so unescaping make sense.