### PR TITLE
Refactor serialiser

### DIFF
--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -47,10 +47,6 @@ abstract class Serialiser
 {
     protected $prefixes = array();
 
-    public function __construct()
-    {
-    }
-
     /**
      * Keep track of the prefixes used while serialising
      * @ignore

--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -65,7 +65,7 @@ abstract class Serialiser
     {
         if (is_null($format) or $format == '') {
             throw new \InvalidArgumentException(
-                "\$format cannot be null or empty"
+                '$format cannot be null or empty'
             );
         } elseif (is_object($format) and ($format instanceof Format)) {
             $format = $format->getName();

--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -88,7 +88,7 @@ abstract class Serialiser
      * property is returned instead.
      * @ignore
      */
-    protected function reversePropertyCount($resource)
+    protected function reversePropertyCount(Resource $resource)
     {
         $properties = $resource->reversePropertyUris();
         $count = count($properties);

--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -100,9 +100,15 @@ abstract class Serialiser
         }
     }
 
+
     /**
-     * Sub-classes must follow this protocol
-     * @ignore
+     * Serialise an EasyRdf\Graph into desired format.
+     *
+     * @param Graph         $graph  An EasyRdf\Graph object.
+     * @param Format|string $format The name of the format to convert to.
+     * @param array         $options
+     *
+     * @return string The RDF in the new desired format.
      */
-    abstract public function serialise($graph, $format, array $options = array());
+    abstract public function serialise(Graph $graph, $format, array $options = array());
 }

--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -61,14 +61,8 @@ abstract class Serialiser
      * Check and cleanup parameters passed to serialise() method
      * @ignore
      */
-    protected function checkSerialiseParams(&$graph, &$format)
+    protected function checkSerialiseParams(&$format)
     {
-        if (is_null($graph) or !is_object($graph) or !($graph instanceof Graph)) {
-            throw new \InvalidArgumentException(
-                '$graph should be an EasyRdf\Graph object and cannot be null'
-            );
-        }
-
         if (is_null($format) or $format == '') {
             throw new \InvalidArgumentException(
                 "\$format cannot be null or empty"

--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -43,7 +43,7 @@ namespace EasyRdf;
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-class Serialiser
+abstract class Serialiser
 {
     protected $prefixes = array();
 
@@ -108,10 +108,5 @@ class Serialiser
      * Sub-classes must follow this protocol
      * @ignore
      */
-    public function serialise($graph, $format, array $options = array())
-    {
-        throw new Exception(
-            "This method should be overridden by sub-classes."
-        );
-    }
+    abstract public function serialise($graph, $format, array $options = array());
 }

--- a/lib/Serialiser/Arc.php
+++ b/lib/Serialiser/Arc.php
@@ -78,7 +78,7 @@ class Arc extends RdfPhp
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         if (array_key_exists($format, self::$supportedTypes)) {
             $className = self::$supportedTypes[$format];

--- a/lib/Serialiser/Arc.php
+++ b/lib/Serialiser/Arc.php
@@ -65,18 +65,18 @@ class Arc extends RdfPhp
         }
     }
 
+
     /**
      * Serialise an EasyRdf\Graph into RDF format of choice.
      *
-     * @param Graph  $graph   An EasyRdf\Graph object.
-     * @param string $format  The name of the format to convert to.
+     * @param Graph  $graph  An EasyRdf\Graph object.
+     * @param string $format The name of the format to convert to.
      * @param array  $options
      *
+     * @return string The RDF in the new desired format.
      * @throws Exception
-     *
-     * @return string              The RDF in the new desired format.
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/Arc.php
+++ b/lib/Serialiser/Arc.php
@@ -61,7 +61,7 @@ class Arc extends RdfPhp
     public function __construct()
     {
         if (!class_exists('ARC2')) {
-            throw new \EasyRdf\Exception('ARC2 dependency is not installed');
+            throw new Exception('ARC2 dependency is not installed');
         }
     }
 

--- a/lib/Serialiser/Arc.php
+++ b/lib/Serialiser/Arc.php
@@ -88,6 +88,7 @@ class Arc extends RdfPhp
             );
         }
 
+        /** @var \ARC2_RDFSerializer $serialiser */
         $serialiser = \ARC2::getSer($className);
         if ($serialiser) {
             return $serialiser->getSerializedIndex(

--- a/lib/Serialiser/GraphViz.php
+++ b/lib/Serialiser/GraphViz.php
@@ -252,7 +252,7 @@ class GraphViz extends Serialiser
      *
      * @ignore
      */
-    protected function serialiseDot($graph)
+    protected function serialiseDot(Graph $graph)
     {
         $result = "digraph {\n";
 
@@ -353,7 +353,7 @@ class GraphViz extends Serialiser
      *
      * @ignore
      */
-    public function renderImage($graph, $format = 'png')
+    public function renderImage(Graph $graph, $format = 'png')
     {
         $dot = $this->serialiseDot($graph);
 

--- a/lib/Serialiser/GraphViz.php
+++ b/lib/Serialiser/GraphViz.php
@@ -364,6 +364,7 @@ class GraphViz extends Serialiser
         );
     }
 
+
     /**
      * Serialise an EasyRdf\Graph into a GraphViz dot document.
      *
@@ -373,10 +374,10 @@ class GraphViz extends Serialiser
      * @param string $format The name of the format to convert to.
      * @param array  $options
      *
-     * @throws Exception
      * @return string The RDF in the new desired format.
+     * @throws Exception
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/GraphViz.php
+++ b/lib/Serialiser/GraphViz.php
@@ -61,13 +61,6 @@ class GraphViz extends Serialiser
     private $attributes = array('charset' => 'utf-8');
 
     /**
-     * Constructor
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * Set the path to the GraphViz 'dot' command
      *
      * Default is to search PATH for the command 'dot'.

--- a/lib/Serialiser/GraphViz.php
+++ b/lib/Serialiser/GraphViz.php
@@ -379,7 +379,7 @@ class GraphViz extends Serialiser
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         switch($format) {
             case 'dot':

--- a/lib/Serialiser/Json.php
+++ b/lib/Serialiser/Json.php
@@ -49,20 +49,19 @@ use EasyRdf\Graph;
 class Json extends RdfPhp
 {
     /**
-     * Method to serialise an EasyRdf\Graph to RDF/JSON
+     * Serialise an EasyRdf\Graph into a to RDF/JSON document.
      *
      * http://n2.talis.com/wiki/RDF_JSON_Specification
      * docs/appendix-a-rdf-formats-json.md
      *
-     * @param Graph  $graph   An EasyRdf\Graph object.
-     * @param string $format  The name of the format to convert to.
+     * @param Graph  $graph  An EasyRdf\Graph object.
+     * @param string $format The name of the format to convert to.
      * @param array  $options
      *
-     * @throws Exception
-     *
      * @return string The RDF in the new desired format.
+     * @throws Exception
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/Json.php
+++ b/lib/Serialiser/Json.php
@@ -63,7 +63,7 @@ class Json extends RdfPhp
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         if ($format != 'json') {
             throw new Exception(

--- a/lib/Serialiser/JsonLd.php
+++ b/lib/Serialiser/JsonLd.php
@@ -54,8 +54,6 @@ class JsonLd extends Serialiser
         if (!class_exists('\ML\JsonLD\JsonLD')) {
             throw new \LogicException('Please install "ml/json-ld" dependency to use JSON-LD serialisation');
         }
-
-        parent::__construct();
     }
 
     /**

--- a/lib/Serialiser/JsonLd.php
+++ b/lib/Serialiser/JsonLd.php
@@ -36,6 +36,7 @@ namespace EasyRdf\Serialiser;
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 use EasyRdf\Exception;
+use EasyRdf\Graph;
 use EasyRdf\Serialiser;
 
 use ML\JsonLD as LD;
@@ -56,15 +57,18 @@ class JsonLd extends Serialiser
         }
     }
 
+
     /**
-     * @param \EasyRdf\Graph  $graph
-     * @param string          $format
-     * @param array           $options
+     * Serialise an EasyRdf\Graph into a JSON-LD document.
      *
+     * @param Graph  $graph  An EasyRdf\Graph object.
+     * @param string $format The name of the format to convert to.
+     * @param array  $options
+     *
+     * @return string The RDF in the new desired format.
      * @throws Exception
-     * @return string
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/JsonLd.php
+++ b/lib/Serialiser/JsonLd.php
@@ -70,7 +70,7 @@ class JsonLd extends Serialiser
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         if ($format != 'jsonld') {
             throw new Exception(__CLASS__.' does not support: '.$format);

--- a/lib/Serialiser/Ntriples.php
+++ b/lib/Serialiser/Ntriples.php
@@ -192,18 +192,18 @@ class Ntriples extends Serialiser
         }
     }
 
+
     /**
      * Serialise an EasyRdf\Graph into N-Triples
      *
-     * @param Graph  $graph   An EasyRdf\Graph object.
-     * @param string $format  The name of the format to convert to.
+     * @param Graph  $graph  An EasyRdf\Graph object.
+     * @param string $format The name of the format to convert to.
      * @param array  $options
      *
-     * @throws Exception
-     *
      * @return string The RDF in the new desired format.
+     * @throws Exception
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/Ntriples.php
+++ b/lib/Serialiser/Ntriples.php
@@ -205,7 +205,7 @@ class Ntriples extends Serialiser
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         if ($format == 'ntriples') {
             $nt = '';

--- a/lib/Serialiser/Rapper.php
+++ b/lib/Serialiser/Rapper.php
@@ -85,7 +85,7 @@ class Rapper extends Ntriples
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         $ntriples = parent::serialise($graph, 'ntriples');
 

--- a/lib/Serialiser/Rapper.php
+++ b/lib/Serialiser/Rapper.php
@@ -36,6 +36,7 @@ namespace EasyRdf\Serialiser;
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 use EasyRdf\Exception;
+use EasyRdf\Graph;
 use EasyRdf\Utils;
 
 /**
@@ -71,16 +72,18 @@ class Rapper extends Ntriples
         }
     }
 
+
     /**
      * Serialise an EasyRdf\Graph to the RDF format of choice.
      *
-     * @param \EasyRdf\Graph $graph   An EasyRdf\Graph object.
-     * @param string         $format  The name of the format to convert to.
+     * @param \EasyRdf\Graph $graph  An EasyRdf\Graph object.
+     * @param string         $format The name of the format to convert to.
      * @param array          $options
      *
      * @return string The RDF in the new desired format.
+     * @throws Exception
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/RdfPhp.php
+++ b/lib/Serialiser/RdfPhp.php
@@ -55,14 +55,14 @@ class RdfPhp extends Serialiser
      * http://n2.talis.com/wiki/RDF_PHP_Specification
      * docs/appendix-a-rdf-formats-php.md
      *
-     * @param Graph  $graph   An EasyRdf\Graph object.
-     * @param string $format  The name of the format to convert to.
+     * @param Graph  $graph  An EasyRdf\Graph object.
+     * @param string $format The name of the format to convert to.
      * @param array  $options
      *
-     * @throws Exception
      * @return string The RDF in the new desired format.
+     * @throws Exception
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/RdfPhp.php
+++ b/lib/Serialiser/RdfPhp.php
@@ -64,7 +64,7 @@ class RdfPhp extends Serialiser
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         if ($format != 'php') {
             throw new Exception(

--- a/lib/Serialiser/RdfXml.php
+++ b/lib/Serialiser/RdfXml.php
@@ -205,7 +205,7 @@ class RdfXml extends Serialiser
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         if ($format != 'rdfxml') {
             throw new Exception(

--- a/lib/Serialiser/RdfXml.php
+++ b/lib/Serialiser/RdfXml.php
@@ -196,15 +196,14 @@ class RdfXml extends Serialiser
     /**
      * Method to serialise an EasyRdf\Graph to RDF/XML
      *
-     * @param Graph  $graph   An EasyRdf\Graph object.
-     * @param string $format  The name of the format to convert to.
+     * @param Graph  $graph  An EasyRdf\Graph object.
+     * @param string $format The name of the format to convert to.
      * @param array  $options
      *
-     * @throws Exception
-     *
      * @return string The RDF in the new desired format.
+     * @throws Exception
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/Turtle.php
+++ b/lib/Serialiser/Turtle.php
@@ -352,18 +352,18 @@ class Turtle extends Serialiser
         return $turtle;
     }
 
+
     /**
      * Serialise an EasyRdf\Graph to Turtle.
      *
-     * @param Graph  $graph   An EasyRdf\Graph object.
-     * @param string $format  The name of the format to convert to.
+     * @param Graph  $graph  An EasyRdf\Graph object.
+     * @param string $format The name of the format to convert to.
      * @param array  $options
      *
-     * @throws Exception
-     *
      * @return string The RDF in the new desired format.
+     * @throws Exception
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/lib/Serialiser/Turtle.php
+++ b/lib/Serialiser/Turtle.php
@@ -365,7 +365,7 @@ class Turtle extends Serialiser
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         if ($format != 'turtle' and $format != 'n3') {
             throw new Exception(

--- a/test/EasyRdf/Serialiser/NtriplesArray.php
+++ b/test/EasyRdf/Serialiser/NtriplesArray.php
@@ -80,7 +80,7 @@ class NtriplesArray extends Ntriples
      */
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
 
         $triples = array();
         foreach ($graph->toRdfPhp() as $resource => $properties) {

--- a/test/EasyRdf/Serialiser/NtriplesArray.php
+++ b/test/EasyRdf/Serialiser/NtriplesArray.php
@@ -35,7 +35,9 @@ namespace EasyRdf\Serialiser;
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
+use EasyRdf\Exception;
 use EasyRdf\Format;
+use EasyRdf\Graph;
 
 /**
  * Class to serialise an EasyRdf\Graph to an array of triples.
@@ -65,16 +67,18 @@ class NtriplesArray extends Ntriples
         }
     }
 
+
     /**
      * Serialise an EasyRdf\Graph into an array of N-Triples objects
      *
-     * @param \EasyRdf\Graph  $graph   An EasyRdf\Graph object.
-     * @param string          $format  The name of the format to convert to.
-     * @param array           $options
+     * @param Graph  $graph  An EasyRdf\Graph object.
+     * @param string $format The name of the format to convert to.
+     * @param array  $options
      *
      * @return string The RDF in the new desired format.
+     * @throws Exception
      */
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
 

--- a/test/EasyRdf/SerialiserTest.php
+++ b/test/EasyRdf/SerialiserTest.php
@@ -52,7 +52,7 @@ class SerialiserTest extends TestCase
 {
     private $graph;
     private $resource;
-    /** @var MockSerialiser */
+    /** @var Serialiser */
     private $serialiser;
 
     /**

--- a/test/EasyRdf/SerialiserTest.php
+++ b/test/EasyRdf/SerialiserTest.php
@@ -42,7 +42,7 @@ class MockSerialiser extends Serialiser
 {
     public function serialise(Graph $graph, $format, array $options = array())
     {
-        parent::checkSerialiseParams($graph, $format);
+        parent::checkSerialiseParams($format);
         // Serialising goes here
         return true;
     }

--- a/test/EasyRdf/SerialiserTest.php
+++ b/test/EasyRdf/SerialiserTest.php
@@ -50,7 +50,9 @@ class MockSerialiser extends Serialiser
 
 class SerialiserTest extends TestCase
 {
+    /** @var Graph */
     private $graph;
+    /** @var Resource */
     private $resource;
     /** @var Serialiser */
     private $serialiser;

--- a/test/EasyRdf/SerialiserTest.php
+++ b/test/EasyRdf/SerialiserTest.php
@@ -40,7 +40,7 @@ require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class MockSerialiser extends Serialiser
 {
-    public function serialise($graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = array())
     {
         parent::checkSerialiseParams($graph, $format);
         // Serialising goes here
@@ -78,33 +78,6 @@ class SerialiserTest extends TestCase
         $this->assertTrue(
             $this->serialiser->serialise($this->graph, $format)
         );
-    }
-
-    public function testSerialiseNullGraph()
-    {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            '$graph should be an EasyRdf\Graph object and cannot be null'
-        );
-        $this->serialiser->serialise(null, 'php');
-    }
-
-    public function testSerialiseNonObjectGraph()
-    {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            '$graph should be an EasyRdf\Graph object and cannot be null'
-        );
-        $this->serialiser->serialise('string', 'php');
-    }
-
-    public function testSerialiseNonGraph()
-    {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            '$graph should be an EasyRdf\Graph object and cannot be null'
-        );
-        $this->serialiser->serialise($this->resource, 'php');
     }
 
     public function testSerialiseNullFormat()

--- a/test/EasyRdf/SerialiserTest.php
+++ b/test/EasyRdf/SerialiserTest.php
@@ -142,14 +142,4 @@ class SerialiserTest extends TestCase
         );
         $this->serialiser->serialise($this->graph, 1);
     }
-
-    public function testSerialiseUndefined()
-    {
-        $this->setExpectedException(
-            'EasyRdf\Exception',
-            'This method should be overridden by sub-classes.'
-        );
-        $serialiser = new Serialiser();
-        $serialiser->serialise($this->graph, 'format');
-    }
 }


### PR DESCRIPTION
Since EasyRdf requires PHP 5.3 now it makes sense to clean up the code base to use type hints instead of run-time type checks.

I have started with the `Serialiser` class tree and its `serialise()` method. The `$graph` parameter is now type hinted and corresponding type checks and unit tests removed.

There is a lot that could be refactored to make the code more [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)), but I would like to have some feedback early, so here you go. :smile: 