### PR TITLE
Added a delete method in class EasyRdf_Sparql_Client

### DIFF
--- a/lib/Sparql/Client.php
+++ b/lib/Sparql/Client.php
@@ -205,6 +205,20 @@ class Client
         return $this->update($query);
     }
 
+ public function delete($data, $graphUri = null)
+    {
+        $query = 'DELETE DATA {';
+        if ($graphUri) {
+            $query .= "GRAPH <$graphUri> {";
+        }
+        $query .= $this->convertToTriples($data);
+        if ($graphUri) {
+            $query .= "}";
+        }
+        $query .= '}';
+        return $this->update($query);
+    }
+
     protected function updateData($operation, $data, $graphUri = null)
     {
         $query = "$operation DATA {";


### PR DESCRIPTION
I made a change to easyrdf-0.9.0 to add a delete method. This is a change to the git repository reflecting the file that I changed in easyrdf-0.9.0.  I have a copy in https://github.com/bshambaugh/replacetriples (including easyrdf-0.9.0) with use in https://github.com/bshambaugh/replacetriples/blob/master/combinedscripts.php . The file that used it, combinedscripts.php seemed to function well when I added a different variable name for each query. When I used queries with a common variable name in an earlier version of this code I deleted all matches with the common predicate if I can recall correctly. 