### PR TITLE
Format->guessFormat: Extend RDF/XML guessing

### DIFF
--- a/lib/Format.php
+++ b/lib/Format.php
@@ -284,6 +284,17 @@ class Format
         } elseif (preg_match('/^\s*<.+> <.+>/m', $short)) {
             return self::getFormat('ntriples');
         } else {
+            // in case you have a DOCTYPE element with many ENTITY elements, you should check further parts of the file
+            // first make sure that we have XML
+            if (preg_match('/\<\?xml.*?\?\>/si', $short)) {
+                // get the next portion of the data
+                $short = substr($data, 1024, 2024);
+                // check again for <rdf:
+                if (preg_match('/<rdf:/i', $short)) {
+                    return self::getFormat('rdfxml');
+                }
+            }
+            
             return null;
         }
     }

--- a/lib/Format.php
+++ b/lib/Format.php
@@ -288,7 +288,7 @@ class Format
             // first make sure that we have XML
             if (preg_match('/\<\?xml.*?\?\>/si', $short)) {
                 // get the next portion of the data
-                $short = substr($data, 1024, 2024);
+                $short = substr($data, 1024, 10000);
                 // check again for <rdf:
                 if (preg_match('/<rdf:/i', $short)) {
                     return self::getFormat('rdfxml');


### PR DESCRIPTION
If the DOCTYPE element has to many ENTITY elements, the guess fails and returns null. That can happen, if there are many namespaces to define. With this patch, we extend the string-portion to check from 1024 to 3072 bytes of the content. In some cases that even may not enough, but at least, all major scenarios should be dealt with.