### PR TITLE
regarding #276: try to fix Error: [] operator not supported for strings

### DIFF
--- a/lib/Serialiser/GraphViz.php
+++ b/lib/Serialiser/GraphViz.php
@@ -223,9 +223,9 @@ class GraphViz extends Serialiser
      */
     protected function escapeAttributes($array)
     {
-        $items = '';
+        $items = array();
         foreach ($array as $k => $v) {
-            $items[] = $this->escape($k).'='.$this->escape($v);
+            array_push($items, $this->escape($k).'='.$this->escape($v));
         }
         return '['.implode(',', $items).']';
     }


### PR DESCRIPTION
In #276 the user @siwinski reported, that EasyRdf fails in php 7.1. I adapted the Serialiser/GraphViz.php::**escapeAttributes**:
- in this function $items was used as an array, but was initialized as string (fixed by setting $items = array())
- using $items[] = '...' seems failing in PHP 7.1, therefore using array_push to add string-items

In my local tests (running make test) with PHP 7.1.5 i got rid of the error `Error: [] operator not supported for strings`. Unfortunately, other tests seemed to fail now, but i guess, its for a different reason. For instance:

```
2) EasyRdf\Examples\VillagesTest::testCeres
Exception: Failed to run script (255): PHP Fatal error:  Uncaught EasyRdf\Http\Exception: HTTP request for http://www.dbpedialite.org/things/934787 failed: Bad Request in /var/www/html/vendor/easyrdf/easyrdf/lib/Graph.php:337
Stack trace:
#0 /var/www/html/vendor/easyrdf/easyrdf/lib/Graph.php(115): EasyRdf\Graph->load('http://www.dbpe...', NULL)
#1 /var/www/html/vendor/easyrdf/easyrdf/examples/villages.php(31): EasyRdf\Graph::newAndLoad('http://www.dbpe...')
#2 /var/www/html/vendor/easyrdf/easyrdf/test/cli_example_wrapper.php(43): require('/var/www/html/v...')
#3 {main}
  thrown in /var/www/html/vendor/easyrdf/easyrdf/lib/Graph.php on line 337
<html>
<head><title>EasyRdf Village Info Example</title></head>
<body>
<h1>EasyRdf Village Info Example</h1>
```

Nevertheless, this change may be welcome though.