### PR TITLE
Fix PHP5.3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 php:
   - 7.1
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
+matrix:
+  include:
+    - php: "5.3"
+      dist: precise
 
 install: make composer-install
 script:


### PR DESCRIPTION
Currently PHP5.3 testing is broken because travis does not support PHP5.3 on trusty.