### PR TITLE
Http client configuration parameters

### DIFF
--- a/lib/Http/Client.php
+++ b/lib/Http/Client.php
@@ -59,7 +59,7 @@ class Client
     private $config = array(
         'maxredirects'    => 5,
         'useragent'       => 'EasyRdf HTTP Client',
-        'timeout'         => 10
+        'timeout'         => 30
     );
 
     /**

--- a/lib/Sparql/Client.php
+++ b/lib/Sparql/Client.php
@@ -312,15 +312,16 @@ class Client
     /**
      * Returns an http client.
      */
-    protected function getHttpClient() {
-      if (empty($this->client)) {
-        $this->client = Http::getDefaultHttpClient();
-        $this->client->resetParameters();
-        if (!empty($this->client_config)) {
-          $this->client->setConfig($this->client_config);
+    protected function getHttpClient()
+    {
+        if (empty($this->client)) {
+            $this->client = Http::getDefaultHttpClient();
+            $this->client->resetParameters();
+            if (!empty($this->client_config)) {
+                $this->client->setConfig($this->client_config);
+            }
         }
-      }
-      return $this->client;
+        return $this->client;
     }
 
     /**

--- a/lib/Sparql/Client.php
+++ b/lib/Sparql/Client.php
@@ -51,6 +51,20 @@ use EasyRdf\Utils;
  */
 class Client
 {
+    /**
+     * A list of configuration to be used by the Http Client.
+     *
+     * @var array
+     */
+    private $client_config = array();
+
+    /**
+     * The http client that will be used for the requests.
+     *
+     * @var \EasyRdf\Http\Client
+     */
+    private $client;
+
     /** The query/read address of the SPARQL Endpoint */
     private $queryUri = null;
 
@@ -66,8 +80,9 @@ class Client
      *
      * @param string $queryUri The address of the SPARQL Query Endpoint
      * @param string $updateUri Optional address of the SPARQL Update Endpoint
+     * @param array $client_config An array of configuration for the Client.
      */
-    public function __construct($queryUri, $updateUri = null)
+    public function __construct($queryUri, $updateUri = null, $client_config = array())
     {
         $this->queryUri = $queryUri;
 
@@ -82,6 +97,8 @@ class Client
         } else {
             $this->updateUri = $queryUri;
         }
+
+        $this->client_config = $client_config;
     }
 
     /** Get the URI of the SPARQL query endpoint
@@ -293,6 +310,20 @@ class Client
     }
 
     /**
+     * Returns an http client.
+     */
+    protected function getHttpClient() {
+      if (empty($this->client)) {
+        $this->client = Http::getDefaultHttpClient();
+        $this->client->resetParameters();
+        if (!empty($this->client_config)) {
+          $this->client->setConfig($this->client_config);
+        }
+      }
+      return $this->client;
+    }
+
+    /**
      * Build http-client object, execute request and return a response
      *
      * @param string $processed_query
@@ -303,8 +334,7 @@ class Client
      */
     protected function executeQuery($processed_query, $type)
     {
-        $client = Http::getDefaultHttpClient();
-        $client->resetParameters();
+        $client = $this->getHttpClient();
 
         // Tell the server which response formats we can parse
         $sparql_results_types = array(


### PR DESCRIPTION
Hello, we are using the easyrdf library and we are integrating it with a database layer so that we can use a triplestore as a database.
We are having an issue and I would like to provide a patch if I did not get something wrong. 

Our issue is pretty straightforward. As we are setting this as one of the main database backends of a CMS, it is normal that, depending on the case and the traffic, some queries will take longer to complete than normal. Even though the php timeouts and the server timeouts are set to 30-60s depending on the service, the `\EasyRdf\Http\Client` has a configuration array that sets it to 10s.
The class itself has methods that allow to override the configuration array, however, the `\EasyRdf\Sparql\Client::executeQuery` prepares a default client without allowing any way to override these settings.

I think that since the sparql client is the 'intermediate' class that should be used, we need a way to override the configuration. Also, saying the above, the PR also includes a change to the default timeout and increases it to 30s.

So, due to the above, I have the following questions:
* Is there a reason that the configuration settings cannot be overridden through `\EasyRdf\Sparql\Client`?
* Is there a reason why the timeout is set to 10s by default even though the default php timeout of a request is 30s?