### PR TITLE
modify guessFormat to work with SPARQL-style PREFIX and BASE

### DIFF
--- a/lib/Format.php
+++ b/lib/Format.php
@@ -281,6 +281,8 @@ class Format
             return self::getFormat('rdfa');
         } elseif (preg_match('/@prefix\s|@base\s/', $short)) {
             return self::getFormat('turtle');
+        } elseif (preg_match('/prefix\s|base\s/i', $short)) {
+            return self::getFormat('turtle');
         } elseif (preg_match('/^\s*<.+> <.+>/m', $short)) {
             return self::getFormat('ntriples');
         } else {

--- a/test/EasyRdf/FormatTest.php
+++ b/test/EasyRdf/FormatTest.php
@@ -589,7 +589,7 @@ class FormatTest extends TestCase
         $format = Format::guessFormat(
             '@base <http://one.example/> .'
         );
-        $this->assertSame('turtle', $format);
+        $this->assertStringEquals('turtle', $format);
     }
 
     public function testGuessFormatTurtleSparqlBase()
@@ -597,7 +597,7 @@ class FormatTest extends TestCase
         $format = Format::guessFormat(
             'BASE <http://one.example/>'
         );
-        $this->assertSame('turtle', $format);
+        $this->assertStringEquals('turtle', $format);
     }
 
     public function testGuessFormatTurtlePrefix()
@@ -605,7 +605,7 @@ class FormatTest extends TestCase
         $format = Format::guessFormat(
             '@prefix p: <http://two.example/> .'
         );
-        $this->assertSame('turtle', $format);
+        $this->assertStringEquals('turtle', $format);
     }
 
     public function testGuessFormatTurtleSparqlPrefix()
@@ -613,7 +613,7 @@ class FormatTest extends TestCase
         $format = Format::guessFormat(
             'PREFIX p: <http://two.example/>'
         );
-        $this->assertSame('turtle', $format);
+        $this->assertStringEquals('turtle', $format);
     }
 
     public function testGuessFormatNtriples()

--- a/test/EasyRdf/FormatTest.php
+++ b/test/EasyRdf/FormatTest.php
@@ -584,6 +584,38 @@ class FormatTest extends TestCase
         $this->assertStringEquals('turtle', Format::guessFormat($data));
     }
 
+    public function testGuessFormatTurtleBase()
+    {
+        $format = Format::guessFormat(
+            '@base <http://one.example/> .'
+        );
+        $this->assertSame('turtle', $format);
+    }
+
+    public function testGuessFormatTurtleSparqlBase()
+    {
+        $format = Format::guessFormat(
+            'BASE <http://one.example/>'
+        );
+        $this->assertSame('turtle', $format);
+    }
+
+    public function testGuessFormatTurtlePrefix()
+    {
+        $format = Format::guessFormat(
+            '@prefix p: <http://two.example/> .'
+        );
+        $this->assertSame('turtle', $format);
+    }
+
+    public function testGuessFormatTurtleSparqlPrefix()
+    {
+        $format = Format::guessFormat(
+            'PREFIX p: <http://two.example/>'
+        );
+        $this->assertSame('turtle', $format);
+    }
+
     public function testGuessFormatNtriples()
     {
         $data = readFixture('foaf.nt');


### PR DESCRIPTION
Do a case-insensitive match for prefix or base at start of the file