### PR TITLE
Fix PHP 7.4 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,27 @@
 language: php
-php:
-  - 7.1
-  - 7.0
-  - 5.6
-  - 5.5
-  - 5.4
+matrix:
+  include:
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+      dist: trusty
+    - php: 7.0
+      dist: trusty
+    - php: 7.1
+      dist: trusty
+    - php: 7.2
+      dist: trusty
+    - php: 7.3
+      dist: trusty
+    - php: 7.4snapshot
+    - php: master
+
+jobs:
+  allow_failures:
+    - php: 7.4snapshot
+    - php: master
 
 sudo: required
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "require-dev": {
         "ml/json-ld": "~1.0",
-        "phpunit/PHPUnit": "~4.1",
+        "phpunit/phpunit": "~4.8.36|^6|^7",
         "sami/sami": "~2.0",
         "semsol/arc2": "~2.2",
         "squizlabs/php_codesniffer": "~1.4.3",

--- a/lib/ParsedUri.php
+++ b/lib/ParsedUri.php
@@ -242,7 +242,7 @@ class ParsedUri
         }
 
         // Construct the new normalised path
-        $this->path = implode($newSegments, '/');
+        $this->path = implode('/', $newSegments);
 
         // Allow easy chaining of methods
         return $this;

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -1242,8 +1242,7 @@ class GraphTest extends TestCase
     {
         if (version_compare(PHP_VERSION, '7.4.x-dev', '>')) {
             $class = '\Error';
-        }
-        else {
+        } else {
             $class = '\PHPUnit\Framework\Error\Error';
         }
         $this->setExpectedException(

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -1240,8 +1240,14 @@ class GraphTest extends TestCase
 
     public function testAddInvalidObject()
     {
+        if (version_compare(PHP_VERSION, '7.4.x-dev', '>')) {
+            $class = '\Error';
+        }
+        else {
+            $class = '\PHPUnit\Framework\Error\Error';
+        }
         $this->setExpectedException(
-            '\PHPUnit\Framework\Error\Error',
+            $class,
             'Object of class EasyRdf\GraphTest could not be converted to string'
         );
         $this->graph->add($this->uri, 'rdf:foo', $this);

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -1241,7 +1241,7 @@ class GraphTest extends TestCase
     public function testAddInvalidObject()
     {
         $this->setExpectedException(
-            'PHPUnit_Framework_Error',
+            '\PHPUnit\Framework\Error\Error',
             'Object of class EasyRdf\GraphTest could not be converted to string'
         );
         $this->graph->add($this->uri, 'rdf:foo', $this);

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -733,8 +733,14 @@ class ResourceTest extends TestCase
     public function testAddInvalidObject()
     {
         $this->setupTestGraph();
+        if (version_compare(PHP_VERSION, '7.4.x-dev', '>')) {
+          $class = '\Error';
+        }
+        else {
+          $class = '\PHPUnit\Framework\Error\Error';
+        }
         $this->setExpectedException(
-            '\PHPUnit\Framework\Error\Error',
+            $class,
             'Object of class EasyRdf\ResourceTest could not be converted to string'
         );
         $this->resource->add('rdf:foo', $this);

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -734,10 +734,9 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         if (version_compare(PHP_VERSION, '7.4.x-dev', '>')) {
-          $class = '\Error';
-        }
-        else {
-          $class = '\PHPUnit\Framework\Error\Error';
+            $class = '\Error';
+        } else {
+            $class = '\PHPUnit\Framework\Error\Error';
         }
         $this->setExpectedException(
             $class,

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -734,7 +734,7 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         $this->setExpectedException(
-            'PHPUnit_Framework_Error',
+            '\PHPUnit\Framework\Error\Error',
             'Object of class EasyRdf\ResourceTest could not be converted to string'
         );
         $this->resource->add('rdf:foo', $this);

--- a/test/EasyRdf/TestCase.php
+++ b/test/EasyRdf/TestCase.php
@@ -36,18 +36,35 @@ namespace EasyRdf;
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+// Backward compatibility layer for PHPUnit 4
+if (!class_exists('\PHPUnit\Framework\Error\Error', TRUE)) {
+  class_alias('PHPUnit_Framework_Error', '\PHPUnit\Framework\Error\Error');
+}
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
 
     public static function assertStringEquals($str1, $str2, $message = null)
     {
-        self::assertSame(strval($str1), strval($str2), $message);
+        self::assertSame(strval($str1), strval($str2), (string) $message);
     }
 
     // Note: this differs from assertInstanceOf because it disallows subclasses
     public static function assertClass($class, $object)
     {
         self::assertSame($class, get_class($object));
+    }
+
+    // Forward compatibility layer for PHPUnit 6/7
+    public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = NULL) {
+      if (method_exists($this, 'expectException')) {
+        $this->expectException($exceptionName);
+        if ($exceptionMessage) {
+          $this->expectExceptionMessage($exceptionMessage);
+        }
+      }
+      else {
+        parent::setExpectedException($exceptionName, $exceptionMessage);
+      }
     }
 }

--- a/test/EasyRdf/TestCase.php
+++ b/test/EasyRdf/TestCase.php
@@ -37,8 +37,8 @@ namespace EasyRdf;
  */
 
 // Backward compatibility layer for PHPUnit 4
-if (!class_exists('\PHPUnit\Framework\Error\Error', TRUE)) {
-  class_alias('PHPUnit_Framework_Error', '\PHPUnit\Framework\Error\Error');
+if (!class_exists('\PHPUnit\Framework\Error\Error', true)) {
+    class_alias('PHPUnit_Framework_Error', '\PHPUnit\Framework\Error\Error');
 }
 
 class TestCase extends \PHPUnit\Framework\TestCase
@@ -56,15 +56,15 @@ class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     // Forward compatibility layer for PHPUnit 6/7
-    public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = NULL) {
-      if (method_exists($this, 'expectException')) {
-        $this->expectException($exceptionName);
-        if ($exceptionMessage) {
-          $this->expectExceptionMessage($exceptionMessage);
+    public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exceptionName);
+            if ($exceptionMessage) {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+        } else {
+            parent::setExpectedException($exceptionName, $exceptionMessage);
         }
-      }
-      else {
-        parent::setExpectedException($exceptionName, $exceptionMessage);
-      }
     }
 }


### PR DESCRIPTION
PHP 7.4 has deprecation `implode(): Passing glue string after array is deprecated. Swap the parameters`

Unfortunately enabling PHP7.4 testing is going to be tricky because all the tests will have to be rewritten because we need to upgrade PHPUnit to version 7 and then we need to decide how to test lower versions of PHP. 