### PR TITLE
composer.json: increase suggested version for semsol/arc2 to ~2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "suggest": {
         "ml/json-ld": "~1.0",
-        "semsol/arc2": "~2.2"
+        "semsol/arc2": "~2.5"
     },
     "require-dev": {
         "ml/json-ld": "~1.0",


### PR DESCRIPTION
*One of the ARC2 maintainers here.*

We have made some improvements since 2.2. I increased the version to `2.5`, so it suggests the latest and most stable version of ARC2.