### PR TITLE
add typing for php 8.4 for ArrayAccess

### DIFF
--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -769,7 +769,7 @@ class Resource implements \ArrayAccess
      *
      * @return boolean true on success or false on failure.
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return $this->__isset($offset);
     }
@@ -786,7 +786,7 @@ class Resource implements \ArrayAccess
      *
      * @return mixed Can return all value types.
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->__get($offset);
     }
@@ -804,7 +804,7 @@ class Resource implements \ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->__set($offset, $value);
     }
@@ -821,7 +821,7 @@ class Resource implements \ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         $this->__unset($offset);
     }


### PR DESCRIPTION
This PR adds typing for the arrayaccess methods - this removes warnings when running the code under php 8.4.

This fixes https://github.com/easyrdf/easyrdf/issues/411
