### PR TITLE
Fix initXMLParser xml_set_object call

### DIFF
--- a/lib/Parser/RdfXml.php
+++ b/lib/Parser/RdfXml.php
@@ -87,10 +87,10 @@ class RdfXml extends Parser
             $parser = xml_parser_create_ns('UTF-8', '');
             xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 0);
             xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
+            xml_set_object($parser, $this);
             xml_set_element_handler($parser, 'startElementHandler', 'endElementHandler');
             xml_set_character_data_handler($parser, 'cdataHandler');
             xml_set_start_namespace_decl_handler($parser, 'newNamespaceHandler');
-            xml_set_object($parser, $this);
             $this->xmlParser = $parser;
         }
     }


### PR DESCRIPTION
The xml_set_object call needs to happen before the xml_set_element_handler call, so it knows the methods in the class and is able to bind the handlers properly

Fixes: #413